### PR TITLE
Let Bluetooth inherit from EventTarget

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -583,7 +583,7 @@ spec: html
       boolean acceptAllDevices = false;
     };
 
-    interface Bluetooth {
+    interface Bluetooth : EventTarget {
       [SecureContext]
       Promise&lt;boolean> getAvailability();
       [SecureContext]
@@ -593,7 +593,6 @@ spec: html
       [SecureContext]
       Promise&lt;BluetoothDevice> requestDevice(optional RequestDeviceOptions options);
     };
-    Bluetooth implements EventTarget;
     Bluetooth implements BluetoothDeviceEventHandlers;
     Bluetooth implements CharacteristicEventHandlers;
     Bluetooth implements ServiceEventHandlers;
@@ -5349,7 +5348,7 @@ spec: html
 
   <pre class="idl">
     partial interface Navigator {
-      readonly attribute Bluetooth bluetooth;
+      [SameObject] readonly attribute Bluetooth bluetooth;
     };
   </pre>
 </section>


### PR DESCRIPTION
This is the same problem as in https://github.com/WICG/webusb/pull/67

Here, too, sprinkle some [SameObject] around.